### PR TITLE
Rust SDK changes for TP to get serialized txn header

### DIFF
--- a/examples/intkey_rust/Cargo.toml
+++ b/examples/intkey_rust/Cargo.toml
@@ -35,6 +35,7 @@ clap = "2"
 log = "0.4"
 log4rs = "0.8"
 cbor-codec = "0.7"
+protobuf="2.0"
 
 [features]
 default = []

--- a/examples/intkey_rust/src/main.rs
+++ b/examples/intkey_rust/src/main.rs
@@ -22,6 +22,7 @@ extern crate crypto;
 #[macro_use]
 extern crate log;
 extern crate log4rs;
+extern crate protobuf;
 extern crate sawtooth_sdk;
 
 mod handler;
@@ -33,6 +34,7 @@ use log4rs::encode::pattern::PatternEncoder;
 
 use std::process;
 
+use sawtooth_sdk::messages::processor::TpRegisterRequest_TpProcessRequestHeaderStyle;
 use sawtooth_sdk::processor::TransactionProcessor;
 
 use handler::IntkeyTransactionHandler;
@@ -92,5 +94,7 @@ fn main() {
     info!("Console logging level: {}", console_log_level);
 
     processor.add_handler(&handler);
+    // Request transaction header bytes in TpProcessRequest
+    processor.set_header_style(TpRegisterRequest_TpProcessRequestHeaderStyle::RAW);
     processor.start();
 }

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -22,9 +22,11 @@ import "transaction.proto";
 
 
 // The registration request from the transaction processor to the
-// validator/executor
+// validator/executor.
+//
+// The protocol_version field is used to check if the validator supports
+// requested features by a transaction processor.
 message TpRegisterRequest {
-
     // A settled upon name for the capabilities of the transaction processor.
     // For example: intkey, xo
     string family = 1;
@@ -42,6 +44,11 @@ message TpRegisterRequest {
     // The maximum number of transactions that this transaction processor can
     // handle at once.
     uint32 max_occupancy = 5;
+
+    // Validator can make use of this field to check if the requested features
+    // are supported. Registration requests can be either accepted or rejected
+    // based on this field.
+    uint32 protocol_version = 6;
 }
 
 // A response sent from the validator to the transaction processor
@@ -54,6 +61,10 @@ message TpRegisterResponse {
     }
 
     Status status = 1;
+
+    // Respond back with protocol_version, the value that can be used by SDK to
+    // know if validator supports expected feature.
+    uint32 protocol_version = 2;
 }
 
 // The unregistration request from the transaction processor to the

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -26,7 +26,21 @@ import "transaction.proto";
 //
 // The protocol_version field is used to check if the validator supports
 // requested features by a transaction processor.
+// Following are the versions supported:
+//     1    Transaction processor can request for either raw header bytes or
+//          deserialized TransactionHeader field in the TpProcessRequest
+//          message. The default option is set to send deserialized
+//          TransactionHeader.
 message TpRegisterRequest {
+    // enum used to fill in transaction header field in TpProcessRequest.
+    // This field can be set before transaction processor registers with
+    // validator.
+    enum TpProcessRequestHeaderStyle {
+        HEADER_STYLE_UNSET = 0;
+        EXPANDED = 1;
+        RAW = 2;
+    }
+
     // A settled upon name for the capabilities of the transaction processor.
     // For example: intkey, xo
     string family = 1;
@@ -49,6 +63,10 @@ message TpRegisterRequest {
     // are supported. Registration requests can be either accepted or rejected
     // based on this field.
     uint32 protocol_version = 6;
+
+    // Setting it to RAW, validator would fill in serialized transaction header
+    // when sending TpProcessRequest to the transaction processor.
+    TpProcessRequestHeaderStyle request_header_style = 7;
 }
 
 // A response sent from the validator to the transaction processor
@@ -90,10 +108,21 @@ message TpUnregisterResponse {
 // The request from the validator/executor of the transaction processor
 // to verify a transaction.
 message TpProcessRequest {
-    TransactionHeader header = 1;  // The transaction header
-    bytes payload = 2;  // The transaction payload
-    string signature = 3;  // The transaction header_signature
-    string context_id = 4; // The context_id for state requests.
+    // The de-serialized transaction header from client request
+    TransactionHeader header = 1;
+
+    // The transaction payload
+    bytes payload = 2;
+
+    // The transaction header_signature
+    string signature = 3;
+
+    // The context_id for state requests.
+    string context_id = 4;
+
+    // The serialized header as received by client.
+    // Controlled by a flag during transaction processor registration.
+    bytes header_bytes = 5;
 }
 
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -37,6 +37,8 @@ use crate::messages::processor::TpProcessRequest;
 use crate::messages::processor::TpProcessResponse;
 use crate::messages::processor::TpProcessResponse_Status;
 use crate::messages::processor::TpRegisterRequest;
+use crate::messages::processor::TpRegisterResponse;
+use crate::messages::processor::TpRegisterResponse_Status;
 use crate::messages::processor::TpUnregisterRequest;
 use crate::messages::validator::Message_MessageType;
 use crate::messaging::stream::MessageConnection;
@@ -52,6 +54,21 @@ use self::handler::ApplyError;
 use self::handler::TransactionHandler;
 use self::zmq_context::ZmqTransactionContext;
 
+// This is the version used by SDK to match if validator supports feature
+// it requested during registration. It should only be incremented when
+// there are changes in TpRegisterRequest. Remember to sync this
+// information in validator if changed.
+// Note: SDK_PROTOCOL_VERSION is the highest version the SDK supports
+#[derive(Debug, Clone)]
+enum FeatureVersion {
+    FeatureUnused = 0,
+}
+
+impl FeatureVersion {
+    pub const FEATURE_UNUSED: FeatureVersion = FeatureVersion::FeatureUnused;
+    pub const SDK_PROTOCOL_VERSION: FeatureVersion = FeatureVersion::FeatureUnused;
+}
+
 /// Generates a random correlation id for use in Message
 fn generate_correlation_id() -> String {
     const LENGTH: usize = 16;
@@ -62,6 +79,7 @@ pub struct TransactionProcessor<'a> {
     endpoint: String,
     conn: ZmqMessageConnection,
     handlers: Vec<&'a dyn TransactionHandler>,
+    highest_sdk_feature_requested: FeatureVersion,
 }
 
 impl<'a> TransactionProcessor<'a> {
@@ -73,6 +91,7 @@ impl<'a> TransactionProcessor<'a> {
             endpoint: String::from(endpoint),
             conn: ZmqMessageConnection::new(endpoint),
             handlers: Vec::new(),
+            highest_sdk_feature_requested: FeatureVersion::FEATURE_UNUSED,
         }
     }
 
@@ -92,6 +111,7 @@ impl<'a> TransactionProcessor<'a> {
                 request.set_family(handler.family_name().clone());
                 request.set_version(version.clone());
                 request.set_namespaces(RepeatedField::from_vec(handler.namespaces().clone()));
+                request.set_protocol_version(self.highest_sdk_feature_requested.clone() as u32);
                 info!(
                     "sending TpRegisterRequest: {} {}",
                     &handler.family_name(),
@@ -123,7 +143,36 @@ impl<'a> TransactionProcessor<'a> {
                 // Absorb the TpRegisterResponse message
                 loop {
                     match future.get_timeout(Duration::from_millis(10000)) {
-                        Ok(_) => break,
+                        Ok(response) => {
+                            let resp: TpRegisterResponse =
+                                match protobuf::parse_from_bytes(&response.get_content()) {
+                                    Ok(read_response) => read_response,
+                                    Err(_) => {
+                                        unregister.store(true, Ordering::SeqCst);
+                                        error!("Error while unpacking TpRegisterResponse");
+                                        return false;
+                                    }
+                                };
+                            // Validator gives backward compatible support, do not proceed if SDK
+                            // is expecting a feature which validator cannot provide
+                            if resp.get_protocol_version() != self.highest_sdk_feature_requested.clone() as u32 {
+                                unregister.store(true, Ordering::SeqCst);
+                                error!(
+                                    "Validator version {} does not support \
+                                    requested feature by SDK version {:?}. \
+                                    Unregistering with the validator.",
+                                    resp.get_protocol_version(),
+                                    self.highest_sdk_feature_requested
+                                );
+                                return false;
+                            }
+                            if resp.get_status() == TpRegisterResponse_Status::ERROR {
+                                unregister.store(true, Ordering::SeqCst);
+                                error!("Transaction processor registration failed");
+                                return false;
+                            }
+                            break;
+                        }
                         Err(_) => {
                             if unregister.load(Ordering::SeqCst) {
                                 return false;


### PR DESCRIPTION
RFC text/0000-raw-txn-header.md describes in brief the need to
have serialized transaction header sent to transaction processor.
1. Introduce required proto changes, set EXPANDED as default.
2. Introduces a new method for setting transaction header style.

Please refer to hyperledger/sawtooth-rfcs#23 for detailed
description.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>