### PR TITLE
Derive PartialEq, Eq, and Hash traits for Block and PeerInfo

### DIFF
--- a/examples/intkey_rust/src/handler.rs
+++ b/examples/intkey_rust/src/handler.rs
@@ -86,7 +86,7 @@ impl IntkeyPayload {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Verb must be 'set', 'inc', or 'dec'",
-                )))
+                )));
             }
             Some(verb_raw) => verb_raw.clone(),
         };
@@ -98,7 +98,7 @@ impl IntkeyPayload {
             _ => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Verb must be 'set', 'inc', or 'dec'",
-                )))
+                )));
             }
         };
 
@@ -108,7 +108,7 @@ impl IntkeyPayload {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Must have a value",
-                )))
+                )));
             }
         };
 
@@ -119,7 +119,7 @@ impl IntkeyPayload {
             _ => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Value must be an integer",
-                )))
+                )));
             }
         };
 
@@ -127,7 +127,7 @@ impl IntkeyPayload {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Name must be a string",
-                )))
+                )));
             }
             Some(name_raw) => name_raw.clone(),
         };
@@ -193,7 +193,7 @@ impl<'a> IntkeyState<'a> {
                     _ => {
                         return Err(ApplyError::InternalError(String::from(
                             "No map returned from state",
-                        )))
+                        )));
                     }
                 };
 
@@ -284,7 +284,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Request must contain a payload",
-                )))
+                )));
             }
         };
 
@@ -306,7 +306,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
                         return Err(ApplyError::InvalidTransaction(format!(
                             "{} already set",
                             payload.get_name()
-                        )))
+                        )));
                     }
                     Ok(None) => (),
                     Err(err) => return Err(err),
@@ -319,7 +319,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
                     Ok(None) => {
                         return Err(ApplyError::InvalidTransaction(String::from(
                             "inc requires a set value",
-                        )))
+                        )));
                     }
                     Err(err) => return Err(err),
                 };
@@ -338,7 +338,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
                     Ok(None) => {
                         return Err(ApplyError::InvalidTransaction(String::from(
                             "dec requires a set value",
-                        )))
+                        )));
                     }
                     Err(err) => return Err(err),
                 };

--- a/examples/xo_rust/src/handler/game.rs
+++ b/examples/xo_rust/src/handler/game.rs
@@ -113,7 +113,7 @@ impl Game {
                 return Err(ApplyError::InvalidTransaction(format!(
                     "Invalid state {}",
                     other_state
-                )))
+                )));
             }
         };
 
@@ -143,7 +143,7 @@ impl Game {
             (true, true) => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Two winners (there can only be one)",
-                )))
+                )));
             }
             (true, false) => Some(String::from("P1-WIN")),
             (false, true) => Some(String::from("P2-WIN")),

--- a/examples/xo_rust/src/handler/mod.rs
+++ b/examples/xo_rust/src/handler/mod.rs
@@ -65,7 +65,7 @@ impl TransactionHandler for XoTransactionHandler {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Invalid header",
-                )))
+                )));
             }
         };
 
@@ -108,7 +108,7 @@ impl TransactionHandler for XoTransactionHandler {
                         "P1-WIN" | "P2-WIN" | "TIE" => {
                             return Err(ApplyError::InvalidTransaction(String::from(
                                 "Invalid action: Game has ended",
-                            )))
+                            )));
                         }
                         "P1-NEXT" => {
                             let p1 = g.get_player1();
@@ -129,7 +129,7 @@ impl TransactionHandler for XoTransactionHandler {
                         _ => {
                             return Err(ApplyError::InvalidTransaction(String::from(
                                 "Invalid state",
-                            )))
+                            )));
                         }
                     }
 

--- a/examples/xo_rust/src/handler/payload.rs
+++ b/examples/xo_rust/src/handler/payload.rs
@@ -31,7 +31,7 @@ impl XoPayload {
             Err(_) => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Invalid payload serialization",
-                )))
+                )));
             }
         };
 
@@ -83,7 +83,7 @@ impl XoPayload {
                 Err(_) => {
                     return Err(ApplyError::InvalidTransaction(String::from(
                         "Space must be an integer",
-                    )))
+                    )));
                 }
             };
             if space_parsed < 1 || space_parsed > 9 {

--- a/src/consensus/engine.rs
+++ b/src/consensus/engine.rs
@@ -25,6 +25,7 @@ use consensus::service::Service;
 
 /// An update from the validator
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Update {
     PeerConnected(PeerInfo),
     PeerDisconnected(PeerId),

--- a/src/consensus/service.rs
+++ b/src/consensus/service.rs
@@ -23,6 +23,7 @@ pub trait Service {
     // -- P2P --
 
     /// Send a consensus message to a specific, connected peer
+    #[allow(clippy::ptr_arg)]
     fn send_to(&mut self, peer: &PeerId, message_type: &str, payload: Vec<u8>)
         -> Result<(), Error>;
 

--- a/src/consensus/zmq_driver.rs
+++ b/src/consensus/zmq_driver.rs
@@ -317,7 +317,7 @@ fn handle_update(
         CONSENSUS_NOTIFY_PEER_DISCONNECTED => {
             let mut request: ConsensusNotifyPeerDisconnected =
                 protobuf::parse_from_bytes(msg.get_content())?;
-            Update::PeerDisconnected(request.take_peer_id().into())
+            Update::PeerDisconnected(request.take_peer_id())
         }
         CONSENSUS_NOTIFY_PEER_MESSAGE => {
             let mut request: ConsensusNotifyPeerMessage =
@@ -327,7 +327,7 @@ fn handle_update(
             let mut message = request.take_message();
             Update::PeerMessage(
                 from_consensus_peer_message(message, header),
-                request.take_sender_id().into(),
+                request.take_sender_id(),
             )
         }
         CONSENSUS_NOTIFY_BLOCK_NEW => {
@@ -338,24 +338,24 @@ fn handle_update(
         CONSENSUS_NOTIFY_BLOCK_VALID => {
             let mut request: ConsensusNotifyBlockValid =
                 protobuf::parse_from_bytes(msg.get_content())?;
-            Update::BlockValid(request.take_block_id().into())
+            Update::BlockValid(request.take_block_id())
         }
         CONSENSUS_NOTIFY_BLOCK_INVALID => {
             let mut request: ConsensusNotifyBlockInvalid =
                 protobuf::parse_from_bytes(msg.get_content())?;
-            Update::BlockInvalid(request.take_block_id().into())
+            Update::BlockInvalid(request.take_block_id())
         }
         CONSENSUS_NOTIFY_BLOCK_COMMIT => {
             let mut request: ConsensusNotifyBlockCommit =
                 protobuf::parse_from_bytes(msg.get_content())?;
-            Update::BlockCommit(request.take_block_id().into())
+            Update::BlockCommit(request.take_block_id())
         }
         CONSENSUS_NOTIFY_ENGINE_DEACTIVATED => Update::Shutdown,
         unexpected => {
             return Err(Error::ReceiveError(format!(
                 "Received unexpected message type: {:?}",
                 unexpected
-            )))
+            )));
         }
     };
 
@@ -371,9 +371,9 @@ fn handle_update(
 impl From<ConsensusBlock> for Block {
     fn from(mut c_block: ConsensusBlock) -> Block {
         Block {
-            block_id: c_block.take_block_id().into(),
-            previous_id: c_block.take_previous_id().into(),
-            signer_id: c_block.take_signer_id().into(),
+            block_id: c_block.take_block_id(),
+            previous_id: c_block.take_previous_id(),
+            signer_id: c_block.take_signer_id(),
             block_num: c_block.get_block_num(),
             payload: c_block.take_payload(),
             summary: c_block.take_summary(),
@@ -384,7 +384,7 @@ impl From<ConsensusBlock> for Block {
 impl From<ConsensusPeerInfo> for PeerInfo {
     fn from(mut c_peer_info: ConsensusPeerInfo) -> PeerInfo {
         PeerInfo {
-            peer_id: c_peer_info.take_peer_id().into(),
+            peer_id: c_peer_info.take_peer_id(),
         }
     }
 }

--- a/src/consensus/zmq_service.rs
+++ b/src/consensus/zmq_service.rs
@@ -16,7 +16,6 @@
  */
 
 use protobuf;
-use protobuf::Message as ProtobufMessage;
 use rand;
 use rand::Rng;
 
@@ -98,7 +97,7 @@ impl Service for ZmqService {
         let mut request = ConsensusSendToRequest::new();
         request.set_content(payload);
         request.set_message_type(message_type.into());
-        request.set_receiver_id((*peer).clone().into());
+        request.set_receiver_id((*peer).clone());
 
         let response: ConsensusSendToResponse = self.rpc(
             &request,
@@ -126,7 +125,7 @@ impl Service for ZmqService {
     fn initialize_block(&mut self, previous_id: Option<BlockId>) -> Result<(), Error> {
         let mut request = ConsensusInitializeBlockRequest::new();
         if let Some(previous_id) = previous_id {
-            request.set_previous_id(previous_id.into());
+            request.set_previous_id(previous_id);
         }
 
         let response: ConsensusInitializeBlockResponse = self.rpc(
@@ -186,7 +185,7 @@ impl Service for ZmqService {
             _ => check_ok!(response, ConsensusFinalizeBlockResponse_Status::OK),
         }?;
 
-        Ok(response.take_block_id().into())
+        Ok(response.take_block_id())
     }
 
     fn cancel_block(&mut self) -> Result<(), Error> {
@@ -228,7 +227,7 @@ impl Service for ZmqService {
 
     fn commit_block(&mut self, block_id: BlockId) -> Result<(), Error> {
         let mut request = ConsensusCommitBlockRequest::new();
-        request.set_block_id(block_id.into());
+        request.set_block_id(block_id);
 
         let response: ConsensusCommitBlockResponse = self.rpc(
             &request,
@@ -245,7 +244,7 @@ impl Service for ZmqService {
 
     fn ignore_block(&mut self, block_id: BlockId) -> Result<(), Error> {
         let mut request = ConsensusIgnoreBlockRequest::new();
-        request.set_block_id(block_id.into());
+        request.set_block_id(block_id);
 
         let response: ConsensusIgnoreBlockResponse = self.rpc(
             &request,
@@ -262,7 +261,7 @@ impl Service for ZmqService {
 
     fn fail_block(&mut self, block_id: BlockId) -> Result<(), Error> {
         let mut request = ConsensusFailBlockRequest::new();
-        request.set_block_id(block_id.into());
+        request.set_block_id(block_id);
 
         let response: ConsensusFailBlockResponse = self.rpc(
             &request,
@@ -298,7 +297,7 @@ impl Service for ZmqService {
         Ok(response
             .take_blocks()
             .into_iter()
-            .map(|block| (BlockId::from(block.block_id.clone()), Block::from(block)))
+            .map(|block| (block.block_id.clone(), Block::from(block)))
             .collect())
     }
 
@@ -326,7 +325,7 @@ impl Service for ZmqService {
         keys: Vec<String>,
     ) -> Result<HashMap<String, String>, Error> {
         let mut request = ConsensusSettingsGetRequest::new();
-        request.set_block_id(block_id.into());
+        request.set_block_id(block_id);
         request.set_keys(protobuf::RepeatedField::from_vec(keys));
 
         let mut response: ConsensusSettingsGetResponse = self.rpc(
@@ -354,7 +353,7 @@ impl Service for ZmqService {
         addresses: Vec<String>,
     ) -> Result<HashMap<String, Vec<u8>>, Error> {
         let mut request = ConsensusStateGetRequest::new();
-        request.set_block_id(block_id.into());
+        request.set_block_id(block_id);
         request.set_addresses(protobuf::RepeatedField::from_vec(addresses));
 
         let mut response: ConsensusStateGetResponse = self.rpc(
@@ -383,6 +382,7 @@ mod tests {
     use messages::validator::Message;
     use messaging::stream::MessageConnection;
     use messaging::zmq_stream::ZmqMessageConnection;
+    use protobuf::Message as ProtobufMessage;
     use std::default::Default;
     use std::thread;
     use zmq;

--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -192,7 +192,7 @@ impl TransactionContext {
     /// # Arguments
     ///
     /// * `addresses` - the addresses to fetch
-    #[allow(needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn get_state(&mut self, addresses: Vec<String>) -> Result<Option<Vec<u8>>, ContextError> {
         let mut request = TpStateGetRequest::new();
         request.set_context_id(self.context_id.clone());
@@ -214,7 +214,7 @@ impl TransactionContext {
                     None => {
                         return Err(ContextError::ResponseAttributeError(String::from(
                             "TpStateGetResponse is missing entries.",
-                        )))
+                        )));
                     }
                 };
                 match entry.get_data().len() {
@@ -241,7 +241,7 @@ impl TransactionContext {
     ///
     /// * `address` - address of where to store the data
     /// * `paylaod` - payload is the data to store at the address
-    #[allow(needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn set_state(&mut self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
         let state_entries: Vec<TpStateEntry> = entries
             .iter()
@@ -287,7 +287,7 @@ impl TransactionContext {
     /// # Arguments
     ///
     /// * `addresses` - the addresses to fetch
-    #[allow(needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn delete_state(
         &mut self,
         addresses: Vec<String>,

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -171,7 +171,7 @@ impl<'a> TransactionProcessor<'a> {
     /// Connects the transaction processor to a validator and starts
     /// listening for requests and routing them to an appropriate
     /// transaction handler.
-    #[allow(cyclomatic_complexity)]
+    #[allow(clippy::cyclomatic_complexity)]
     pub fn start(&mut self) {
         let unregister = Arc::new(AtomicBool::new(false));
         let r = unregister.clone();
@@ -199,9 +199,7 @@ impl<'a> TransactionProcessor<'a> {
             }
 
             // if registration is not succesful, retry
-            if self.register(&sender, &unregister.clone()) {
-                ()
-            } else {
+            if !self.register(&sender, &unregister.clone()) {
                 continue;
             }
 


### PR DESCRIPTION
Deriving these traits will enable consensus engines to store `Block`s and `PeerInfo`s in collections like `HashSet` and `HashMap`.