### PR TITLE
Make TransactionContext generic

### DIFF
--- a/examples/intkey_rust/src/handler.rs
+++ b/examples/intkey_rust/src/handler.rs
@@ -160,12 +160,12 @@ impl IntkeyPayload {
 }
 
 pub struct IntkeyState<'a> {
-    context: &'a mut TransactionContext,
+    context: &'a TransactionContext,
     get_cache: HashMap<String, BTreeMap<Key, Value>>,
 }
 
 impl<'a> IntkeyState<'a> {
-    pub fn new(context: &'a mut TransactionContext) -> IntkeyState {
+    pub fn new(context: &'a TransactionContext) -> IntkeyState {
         IntkeyState {
             context,
             get_cache: HashMap::new(),
@@ -272,7 +272,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
     fn apply(
         &self,
         request: &TpProcessRequest,
-        context: &mut TransactionContext,
+        context: &TransactionContext,
     ) -> Result<(), ApplyError> {
         let payload = IntkeyPayload::new(request.get_payload());
         let payload = match payload {

--- a/examples/xo_rust/src/handler/mod.rs
+++ b/examples/xo_rust/src/handler/mod.rs
@@ -57,7 +57,7 @@ impl TransactionHandler for XoTransactionHandler {
     fn apply(
         &self,
         request: &TpProcessRequest,
-        context: &mut TransactionContext,
+        context: &TransactionContext,
     ) -> Result<(), ApplyError> {
         let header = &request.header;
         let signer = match &header.as_ref() {

--- a/examples/xo_rust/src/handler/state.rs
+++ b/examples/xo_rust/src/handler/state.rs
@@ -31,12 +31,12 @@ pub fn get_xo_prefix() -> String {
 }
 
 pub struct XoState<'a> {
-    context: &'a mut TransactionContext,
+    context: &'a TransactionContext,
     address_map: HashMap<String, Option<String>>,
 }
 
 impl<'a> XoState<'a> {
-    pub fn new(context: &'a mut TransactionContext) -> XoState {
+    pub fn new(context: &'a TransactionContext) -> XoState {
         XoState {
             context,
             address_map: HashMap::new(),

--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -510,7 +510,7 @@ pub trait TransactionHandler {
     fn apply(
         &self,
         request: &TpProcessRequest,
-        context: &mut TransactionContext,
+        context: &TransactionContext,
     ) -> Result<(), ApplyError>;
 }
 

--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -163,6 +163,23 @@ impl From<ReceiveError> for ContextError {
     }
 }
 
+pub trait Context {
+    fn get_state(&self, addresses: Vec<String>) -> Result<Option<Vec<u8>>, ContextError>;
+
+    fn set_state(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError>;
+
+    fn delete_state(&self, addresses: Vec<String>) -> Result<Option<Vec<String>>, ContextError>;
+
+    fn add_receipt_data(&self, data: &[u8]) -> Result<(), ContextError>;
+
+    fn add_event(
+        &self,
+        event_type: String,
+        attributes: Vec<(String, String)>,
+        data: &[u8],
+    ) -> Result<(), ContextError>;
+}
+
 #[derive(Clone)]
 pub struct TransactionContext {
     context_id: String,
@@ -440,3 +457,38 @@ pub trait TransactionHandler {
         context: &mut TransactionContext,
     ) -> Result<(), ApplyError>;
 }
+
+pub struct TransactionContext {
+    context: Box<Context>,
+}
+
+impl TransactionContext {
+    pub fn get_state(&self, addresses: Vec<String>) -> Result<Option<Vec<u8>>, ContextError> {
+        self.context.get_state(addresses)
+    }
+
+    pub fn set_state(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
+        self.context.set_state(entries)
+    }
+
+    pub fn delete_state(
+        &self,
+        addresses: Vec<String>,
+    ) -> Result<Option<Vec<String>>, ContextError> {
+        self.context.delete_state(addresses)
+    }
+
+    pub fn add_receipt_data(&self, data: &[u8]) -> Result<(), ContextError> {
+        self.context.add_receipt_data(data)
+    }
+
+    pub fn add_event(
+        &self,
+        event_type: String,
+        attributes: Vec<(String, String)>,
+        data: &[u8],
+    ) -> Result<(), ContextError> {
+        self.context.add_event(event_type, attributes, data)
+    }
+}
+

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -49,8 +49,8 @@ use protobuf::Message as M;
 use protobuf::RepeatedField;
 
 use self::handler::ApplyError;
-use self::handler::TransactionContext;
 use self::handler::TransactionHandler;
+use self::handler::TxnContext;
 
 /// Generates a random correlation id for use in Message
 fn generate_correlation_id() -> String {
@@ -240,13 +240,12 @@ impl<'a> TransactionProcessor<'a> {
                                         }
                                     };
 
-                                let mut context = TransactionContext::new(
-                                    request.get_context_id(),
-                                    sender.clone(),
-                                );
+                                let context =
+                                    TxnContext::new(request.get_context_id(), sender.clone())
+                                        .into();
 
                                 let mut response = TpProcessResponse::new();
-                                match self.handlers[0].apply(&request, &mut context) {
+                                match self.handlers[0].apply(&request, &context) {
                                     Ok(()) => {
                                         info!("TP_PROCESS_REQUEST sending TpProcessResponse: OK");
                                         response.set_status(TpProcessResponse_Status::OK);


### PR DESCRIPTION
This does 2 things:
- Make the TransactionContext not be tied to ZeroMQ, which is useful for testing the TransactionHandler without using the network.
- Make the Context trait use `&self` instead of `&mut self` methods