### PR TITLE
Update set_state and delete_state to match get_state_entry/entries

### DIFF
--- a/examples/intkey_rust/src/handler.rs
+++ b/examples/intkey_rust/src/handler.rs
@@ -230,10 +230,8 @@ impl<'a> IntkeyState<'a> {
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
 
         let packed = e.into_inner().into_writer().into_inner();
-        let mut sets = HashMap::new();
-        sets.insert(IntkeyState::calculate_address(name), packed);
         self.context
-            .set_state(sets)
+            .set_state_entry(IntkeyState::calculate_address(name), packed)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
 
         Ok(())

--- a/examples/xo_rust/src/handler/state.rs
+++ b/examples/xo_rust/src/handler/state.rs
@@ -86,9 +86,8 @@ impl<'a> XoState<'a> {
         let state_string = Game::serialize_games(games);
         self.address_map
             .insert(address.clone(), Some(state_string.clone()));
-        let mut sets = HashMap::new();
-        sets.insert(address, state_string.into_bytes());
-        self.context.set_state(sets)?;
+        self.context
+            .set_state_entry(address, state_string.into_bytes())?;
         Ok(())
     }
 
@@ -97,7 +96,7 @@ impl<'a> XoState<'a> {
         if self.address_map.contains_key(&address) {
             self.address_map.insert(address.clone(), None);
         }
-        self.context.delete_state(&[address])?;
+        self.context.delete_state_entry(&address)?;
         Ok(())
     }
 

--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -175,7 +175,7 @@ pub trait TransactionContext {
     /// # Arguments
     ///
     /// * `address` - the address to fetch
-    fn get_state_entry(&self, addresses: &str) -> Result<Option<Vec<u8>>, ContextError>;
+    fn get_state_entry(&self, address: &str) -> Result<Option<Vec<u8>>, ContextError>;
 
     /// get_state_entries queries the validator state for data at each of the
     /// addresses in the given list. The addresses that have been set

--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Bitwise IO, Inc.
+ * Copyright 2019 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,21 +194,65 @@ pub trait TransactionContext {
         note = "please use `set_state_entry` or `set_state_entries` instead"
     )]
     /// set_state requests that each address in the provided map be
+    /// set in validator state to its corresponding value. set_state is deprecated, please use
+    /// set_state_entry to set_state_entries instead
+    ///
+    /// # Arguments
+    ///
+    /// * `entries` - entries are a hashmap where the key is an address and value is the data
+    fn set_state(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
+        self.set_state_entries(entries)
+    }
+
+    /// set_state_entry requests that the provided address is set in the validator state to its
+    /// corresponding value.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - address of where to store the data
+    /// * `data` - payload is the data to store at the address
+    fn set_state_entry(&self, address: String, data: Vec<u8>) -> Result<(), ContextError>;
+
+    /// set_state_entries requests that each address in the provided map be
     /// set in validator state to its corresponding value.
     ///
     /// # Arguments
     ///
-    /// * `entries` - entries are a hashmap where the key is and address and value is the data
-    fn set_state(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError>;
+    /// * `entries` - entries are a hashmap where the key is an address and value is the data
+    fn set_state_entries(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError>;
 
     /// delete_state requests that each of the provided addresses be unset
-    /// in validator state. A list of successfully deleted addresses
-    ///  is returned.
+    /// in validator state. A list of successfully deleted addresses is returned.
+    /// delete_state is deprecated, please use delete_state_entry to delete_state_entries instead
     ///
     /// # Arguments
     ///
-    /// * `addresses` - the addresses to fetch
-    fn delete_state(&self, addresses: &[String]) -> Result<Option<Vec<String>>, ContextError>;
+    /// * `addresses` - the addresses to delete
+    #[deprecated(
+        since = "0.3.0",
+        note = "please use `delete_state_entry` or `delete_state_entries` instead"
+    )]
+    fn delete_state(&self, addresses: &[String]) -> Result<Vec<String>, ContextError> {
+        self.delete_state_entries(addresses)
+    }
+
+    /// delete_state_entry requests that the provided address be unset
+    /// in validator state. A list of successfully deleted addresses
+    /// is returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - the address to delete
+    fn delete_state_entry(&self, address: &str) -> Result<Option<String>, ContextError>;
+
+    /// delete_state_entries requests that each of the provided addresses be unset
+    /// in validator state. A list of successfully deleted addresses
+    /// is returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `addresses` - the addresses to delete
+    fn delete_state_entries(&self, addresses: &[String]) -> Result<Vec<String>, ContextError>;
 
     /// add_receipt_data adds a blob to the execution result for this transaction
     ///

--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -201,7 +201,8 @@ pub trait TransactionContext {
     ///
     /// * `entries` - entries are a hashmap where the key is an address and value is the data
     fn set_state(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
-        self.set_state_entries(entries)
+        let state_entries: Vec<(String, Vec<u8>)> = entries.into_iter().collect();
+        self.set_state_entries(state_entries)
     }
 
     /// set_state_entry requests that the provided address is set in the validator state to its
@@ -219,7 +220,7 @@ pub trait TransactionContext {
     /// # Arguments
     ///
     /// * `entries` - entries are a hashmap where the key is an address and value is the data
-    fn set_state_entries(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError>;
+    fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError>;
 
     /// delete_state requests that each of the provided addresses be unset
     /// in validator state. A list of successfully deleted addresses is returned.

--- a/src/processor/zmq_context.rs
+++ b/src/processor/zmq_context.rs
@@ -152,8 +152,46 @@ impl TransactionContext for ZmqTransactionContext {
     /// # Arguments
     ///
     /// * `address` - address of where to store the data
-    /// * `payload` - payload is the data to store at the address
-    fn set_state(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
+    /// * `data` - data is the data to store at the address
+    fn set_state_entry(&self, address: String, data: Vec<u8>) -> Result<(), ContextError> {
+        let mut entry = TpStateEntry::new();
+        entry.set_address(address.to_string());
+        entry.set_data(data);
+
+        let mut request = TpStateSetRequest::new();
+        request.set_context_id(self.context_id.clone());
+        request.set_entries(RepeatedField::from_vec(vec![entry]));
+        let serialized = request.write_to_bytes()?;
+        let x: &[u8] = &serialized;
+
+        let mut future = self.sender.send(
+            Message_MessageType::TP_STATE_SET_REQUEST,
+            &generate_correlation_id(),
+            x,
+        )?;
+
+        let response: TpStateSetResponse = protobuf::parse_from_bytes(future.get()?.get_content())?;
+        match response.get_status() {
+            TpStateSetResponse_Status::OK => Ok(()),
+            TpStateSetResponse_Status::AUTHORIZATION_ERROR => {
+                Err(ContextError::AuthorizationError(format!(
+                    "Tried to set unauthorized address: {:?}",
+                    address
+                )))
+            }
+            TpStateSetResponse_Status::STATUS_UNSET => Err(ContextError::ResponseAttributeError(
+                String::from("Status was not set for TpStateSetResponse"),
+            )),
+        }
+    }
+
+    /// set_state requests that each address in the provided map be
+    /// set in validator state to its corresponding value.
+    ///
+    /// # Arguments
+    ///
+    /// * `entries` - entries are a hashmap where the key is an address and value is the data
+    fn set_state_entries(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
         let state_entries: Vec<TpStateEntry> = entries
             .into_iter()
             .map(|(address, payload)| {
@@ -181,7 +219,7 @@ impl TransactionContext for ZmqTransactionContext {
             TpStateSetResponse_Status::OK => Ok(()),
             TpStateSetResponse_Status::AUTHORIZATION_ERROR => {
                 Err(ContextError::AuthorizationError(format!(
-                    "Tried to set unauthorized address: {:?}",
+                    "Tried to set unauthorized addresses: {:?}",
                     state_entries
                 )))
             }
@@ -191,14 +229,59 @@ impl TransactionContext for ZmqTransactionContext {
         }
     }
 
-    /// delete_state requests that each of the provided addresses be unset
+    /// delete_state_entry requests that the provided address be unset
     /// in validator state. A list of successfully deleted addresses
-    ///  is returned.
+    /// is returned.
     ///
     /// # Arguments
     ///
-    /// * `addresses` - the addresses to fetch
-    fn delete_state(&self, addresses: &[String]) -> Result<Option<Vec<String>>, ContextError> {
+    /// * `address` - the address to delete
+    fn delete_state_entry(&self, address: &str) -> Result<Option<String>, ContextError> {
+        let mut request = TpStateDeleteRequest::new();
+        request.set_context_id(self.context_id.clone());
+        request.set_addresses(RepeatedField::from_vec(vec![address.to_string()]));
+
+        let serialized = request.write_to_bytes()?;
+        let x: &[u8] = &serialized;
+
+        let mut future = self.sender.send(
+            Message_MessageType::TP_STATE_DELETE_REQUEST,
+            &generate_correlation_id(),
+            x,
+        )?;
+
+        let response: TpStateDeleteResponse =
+            protobuf::parse_from_bytes(future.get()?.get_content())?;
+        match response.get_status() {
+            TpStateDeleteResponse_Status::OK => {
+                if let Some(address) = response.get_addresses().first() {
+                    Ok(Some(address.to_string()))
+                } else {
+                    Ok(None)
+                }
+            }
+            TpStateDeleteResponse_Status::AUTHORIZATION_ERROR => {
+                Err(ContextError::AuthorizationError(format!(
+                    "Tried to delete unauthorized address: {:?}",
+                    address
+                )))
+            }
+            TpStateDeleteResponse_Status::STATUS_UNSET => {
+                Err(ContextError::ResponseAttributeError(String::from(
+                    "Status was not set for TpStateDeleteResponse",
+                )))
+            }
+        }
+    }
+
+    /// delete_state_entries requests that each of the provided addresses be unset
+    /// in validator state. A list of successfully deleted addresses
+    /// is returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `addresses` - the addresses to delete
+    fn delete_state_entries(&self, addresses: &[String]) -> Result<Vec<String>, ContextError> {
         let mut request = TpStateDeleteRequest::new();
         request.set_context_id(self.context_id.clone());
         request.set_addresses(RepeatedField::from_slice(addresses));
@@ -215,10 +298,10 @@ impl TransactionContext for ZmqTransactionContext {
         let response: TpStateDeleteResponse =
             protobuf::parse_from_bytes(future.get()?.get_content())?;
         match response.get_status() {
-            TpStateDeleteResponse_Status::OK => Ok(Some(Vec::from(response.get_addresses()))),
+            TpStateDeleteResponse_Status::OK => Ok(Vec::from(response.get_addresses())),
             TpStateDeleteResponse_Status::AUTHORIZATION_ERROR => {
                 Err(ContextError::AuthorizationError(format!(
-                    "Tried to delete unauthorized address: {:?}",
+                    "Tried to delete unauthorized addresses: {:?}",
                     addresses
                 )))
             }

--- a/src/processor/zmq_context.rs
+++ b/src/processor/zmq_context.rs
@@ -16,8 +16,6 @@
  * -----------------------------------------------------------------------------
  */
 
-use std::collections::HashMap;
-
 use protobuf::Message as M;
 use protobuf::RepeatedField;
 
@@ -191,13 +189,13 @@ impl TransactionContext for ZmqTransactionContext {
     /// # Arguments
     ///
     /// * `entries` - entries are a hashmap where the key is an address and value is the data
-    fn set_state_entries(&self, entries: HashMap<String, Vec<u8>>) -> Result<(), ContextError> {
+    fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
         let state_entries: Vec<TpStateEntry> = entries
             .into_iter()
             .map(|(address, payload)| {
                 let mut entry = TpStateEntry::new();
-                entry.set_address(address.to_string());
-                entry.set_data(payload.to_vec());
+                entry.set_address(address);
+                entry.set_data(payload);
                 entry
             })
             .collect();


### PR DESCRIPTION
This PR deprecates the use of set_state and replaces it with set_state_entry and set_state_entries. Also fixes the return type of set_state_functions to match other sdks. 

This PR also deprecates delete_state and replaces it with delete_state_entry and delete_state_entreis. 