### PR TITLE
Send Disconnect Error on Shutdown, etc

### DIFF
--- a/src/messaging/zmq_stream.rs
+++ b/src/messaging/zmq_stream.rs
@@ -292,10 +292,14 @@ impl SendReceiveStream {
                 }
                 Ok(SocketCommand::Shutdown) => {
                     trace!("Shutdown Signal Received");
+                    self.inbound_router
+                        .route(Err(ReceiveError::DisconnectedError));
                     break;
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     debug!("Disconnected outbound channel");
+                    self.inbound_router
+                        .route(Err(ReceiveError::DisconnectedError));
                     break;
                 }
                 _ => continue,


### PR DESCRIPTION
Send a `DisconnectError` on Shutdown of the stream as well as when the internal receiver has been disconnected (i.e. all of it senders have dropped).  This will trigger any callers to act accordingly.

Future PR's may wish to redesign this API overall, where there is a differentiation between local (i.e. directed by the same process) disconnects and remote disconnects (e.g. the validator has disappeared).