### PR TITLE
Report error instead of unwrapping when send fails

### DIFF
--- a/src/messaging/zmq_stream.rs
+++ b/src/messaging/zmq_stream.rs
@@ -120,9 +120,10 @@ impl MessageSender for ZmqMessageSender {
                     .expect_reply(String::from(correlation_id)),
             );
 
-            sender.send(SocketCommand::Send(msg)).unwrap();
-
-            Ok(future)
+            match sender.send(SocketCommand::Send(msg)) {
+                Ok(_) => Ok(future),
+                Err(_) => Err(SendError::UnknownError),
+            }
         } else {
             Err(SendError::DisconnectedError)
         }


### PR DESCRIPTION
When `ZmqMessageSender.send` fails to send a message, it should report
an error rather than panic.

Signed-off-by: Logan Seeley <seeley@bitwise.io>