### PR TITLE
Don't shutdown on receiving unexpected msg type

### DIFF
--- a/src/consensus/zmq_driver.rs
+++ b/src/consensus/zmq_driver.rs
@@ -352,10 +352,11 @@ fn handle_update(
         }
         CONSENSUS_NOTIFY_ENGINE_DEACTIVATED => Update::Shutdown,
         unexpected => {
-            return Err(Error::ReceiveError(format!(
-                "Received unexpected message type: {:?}",
+            warn!(
+                "Received unexpected message type: {:?}; ignoring",
                 unexpected
-            )));
+            );
+            return Ok(());
         }
     };
 


### PR DESCRIPTION
The consensus engine driver should not shutdown when an unexpected
message type is encountered; it should log an error and continue to run.

Signed-off-by: Logan Seeley <seeley@bitwise.io>