### PR TITLE
Allow additional protocols for consensus engines

### DIFF
--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -79,10 +79,17 @@ message ConsensusStateEntry {
 
 // Sent to connect with the validator
 message ConsensusRegisterRequest {
+  message Protocol {
+    string name = 1;
+    string version = 2;
+  }
+
   // The name of this consensus engine
   string name = 1;
   // The version of this consensus engine
   string version = 2;
+  // Any additional name/version pairs the consensus engine supports
+  repeated Protocol additional_protocols = 3;
 }
 
 message ConsensusRegisterResponse {

--- a/src/consensus/engine.rs
+++ b/src/consensus/engine.rs
@@ -138,6 +138,9 @@ pub trait Engine {
 
     /// Get the name of the engine, typically the algorithm being implemented
     fn name(&self) -> String;
+
+    /// Any additional name/version pairs this engine supports
+    fn additional_protocols(&self) -> Vec<(String, String)>;
 }
 
 /// State provided to an engine when it is started
@@ -300,6 +303,9 @@ pub mod tests {
         }
         fn name(&self) -> String {
             "mock".into()
+        }
+        fn additional_protocols(&self) -> Vec<(String, String)> {
+            vec![("1".into(), "Mock".into())]
         }
     }
 


### PR DESCRIPTION
Corresponds to sawtooth-core PR: https://github.com/hyperledger/sawtooth-core/pull/2130

Adds an (optional) list of additional protocols that a consensus engine
supports as part of the registration process. These additional protocols
can be used for backwards compatiblity. If the values of the
`sawtooth.consensus.algorithm.name` and
`sawtooth.consensus.algorithm.version` settings match the name/version
of an engine or the name/version pair is in the engine's list of
additional protocols, that engine will be activated.

Signed-off-by: Logan Seeley <seeley@bitwise.io>