### PR TITLE
Fix versioning of packaged Rust components

### DIFF
--- a/examples/intkey_rust/Dockerfile-installed-bionic
+++ b/examples/intkey_rust/Dockerfile-installed-bionic
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/examples/intkey_rust/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== intkey rust docker build ===-------------
 FROM ubuntu:bionic

--- a/examples/intkey_rust/Dockerfile-installed-xenial
+++ b/examples/intkey_rust/Dockerfile-installed-xenial
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/examples/intkey_rust/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== intkey rust docker build ===-------------
 FROM ubuntu:xenial

--- a/examples/xo_rust/Dockerfile-installed-bionic
+++ b/examples/xo_rust/Dockerfile-installed-bionic
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/examples/xo_rust/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== xo rust docker build ===-------------
 FROM ubuntu:bionic

--- a/examples/xo_rust/Dockerfile-installed-xenial
+++ b/examples/xo_rust/Dockerfile-installed-xenial
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/examples/xo_rust/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== xo rust docker build ===-------------
 FROM ubuntu:xenial


### PR DESCRIPTION
The behavior of cargo-deb was changed to generate version numbers with
tildes instead of dashes. This is causing newly built packages to sort
below older releases.

https://github.com/mmstick/cargo-deb/pull/102

Signed-off-by: Richard Berg <rberg@bitwise.io>