### PR TITLE
Move entrypoint function to main 

### DIFF
--- a/examples/xo_rust/src/handler/mod.rs
+++ b/examples/xo_rust/src/handler/mod.rs
@@ -21,7 +21,7 @@ mod state;
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-        use sabre_sdk::{ApplyError, TpProcessRequest, TransactionContext, TransactionHandler, WasmPtr, execute_entrypoint};
+        use sabre_sdk::{ApplyError, TpProcessRequest, TransactionContext, TransactionHandler,};
     } else {
         use sawtooth_sdk::messages::processor::TpProcessRequest;
         use sawtooth_sdk::processor::handler::{ApplyError, TransactionContext, TransactionHandler};
@@ -172,7 +172,7 @@ impl TransactionHandler for XoTransactionHandler {
 
 #[cfg(target_arch = "wasm32")]
 // Sabre apply must return a bool
-fn apply(
+pub fn apply(
     request: &TpProcessRequest,
     context: &mut dyn TransactionContext,
 ) -> Result<bool, ApplyError> {
@@ -184,10 +184,4 @@ fn apply(
             Err(err)
         }
     }
-}
-
-#[cfg(target_arch = "wasm32")]
-#[no_mangle]
-pub unsafe fn entrypoint(payload: WasmPtr, signer: WasmPtr, signature: WasmPtr) -> i32 {
-    execute_entrypoint(payload, signer, signature, apply)
 }

--- a/examples/xo_rust/src/main.rs
+++ b/examples/xo_rust/src/main.rs
@@ -34,11 +34,11 @@ cfg_if! {
 
         use sawtooth_sdk::processor::TransactionProcessor;
         use sawtooth_xo::handler::XoTransactionHandler;
+    } else {
+        use sawtooth_xo::handler::apply;
+        use sabre_sdk::{WasmPtr, execute_entrypoint};
     }
 }
-
-#[cfg(target_arch = "wasm32")]
-fn main() {}
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
@@ -97,4 +97,13 @@ fn main() {
 
     processor.add_handler(&handler);
     processor.start();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe fn entrypoint(payload: WasmPtr, signer: WasmPtr, signature: WasmPtr) -> i32 {
+    execute_entrypoint(payload, signer, signature, apply)
 }


### PR DESCRIPTION
This is required so the sabre tp can find
the entrypoint function.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>