### PR TITLE
Remove all intermediate library artifacts

### DIFF
--- a/examples/xo_rust/Dockerfile-scar
+++ b/examples/xo_rust/Dockerfile-scar
@@ -61,7 +61,8 @@ RUN cargo build --target wasm32-unknown-unknown --release
 # Remove the auto-generated .rs files and the built files
 RUN rm target/wasm32-unknown-unknown/release/xo-tp-rust* \
     target/wasm32-unknown-unknown/release/deps/xo* \
-    target/wasm32-unknown-unknown/release/libsawtooth_xo.*
+    target/wasm32-unknown-unknown/release/libsawtooth_xo.* \
+    target/wasm32-unknown-unknown/release/deps/libsawtooth_xo*
 
 # Copy over source files
 COPY examples/xo_rust/src /build/examples/xo_rust/src


### PR DESCRIPTION
When building the dependency stage, there is a libsawtooth_xo deps artifact created that, if not deleted, prevents the xo library portion from being recompiled during the final compilation.  Removing this build artifact fixes the issue.