### PR TITLE
replace outdated rust-crypto crate with RustCrypto/hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hex = "0.3"
 protobuf="2"
 secp256k1 = "0.7.1"
 rand = "0.4.2"
-rust-crypto = "0.2.36"
+sha2 = "0.8"
 zmq = "0.9"
 uuid = { version = "0.5", features = ["v4"] }
 log = "0.3"

--- a/examples/intkey_rust/Cargo.toml
+++ b/examples/intkey_rust/Cargo.toml
@@ -26,7 +26,8 @@ path = "src/main.rs"
 
 [dependencies]
 sawtooth-sdk = { path = "../.." }
-rust-crypto = "0.2"
+sha2 = "0.8"
+hex = "0.4"
 clap = "2"
 log = "0.4"
 log4rs = "0.8"

--- a/examples/intkey_rust/src/main.rs
+++ b/examples/intkey_rust/src/main.rs
@@ -18,11 +18,12 @@
 extern crate cbor;
 #[macro_use]
 extern crate clap;
-extern crate crypto;
+extern crate hex;
 #[macro_use]
 extern crate log;
 extern crate log4rs;
 extern crate sawtooth_sdk;
+extern crate sha2;
 
 mod handler;
 

--- a/examples/xo_rust/Cargo.toml
+++ b/examples/xo_rust/Cargo.toml
@@ -35,13 +35,13 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 cfg-if = "0.1"
+sha2 = "0.8"
+hex = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rust-crypto-wasm = "0.3"
 sabre-sdk = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rust-crypto = "0.2"
 sawtooth-sdk = { path = "../.." }
 log = "0.4"
 log4rs = "0.8"

--- a/examples/xo_rust/src/handler/state.rs
+++ b/examples/xo_rust/src/handler/state.rs
@@ -18,8 +18,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::str::from_utf8;
 
-use crypto::digest::Digest;
-use crypto::sha2::Sha512;
+use sha2::{Digest, Sha512};
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
@@ -32,9 +31,7 @@ cfg_if! {
 use crate::handler::game::Game;
 
 pub fn get_xo_prefix() -> String {
-    let mut sha = Sha512::new();
-    sha.input_str("xo");
-    sha.result_str()[..6].to_string()
+    hex::encode(Sha512::digest(b"xo"))[..6].to_string()
 }
 
 pub struct XoState<'a> {
@@ -51,9 +48,8 @@ impl<'a> XoState<'a> {
     }
 
     fn calculate_address(name: &str) -> String {
-        let mut sha = Sha512::new();
-        sha.input_str(name);
-        get_xo_prefix() + &sha.result_str()[..64].to_string()
+        let sha = hex::encode(Sha512::digest(name.as_bytes()))[64..].to_string();
+        get_xo_prefix() + &sha
     }
 
     pub fn delete_game(&mut self, game_name: &str) -> Result<(), ApplyError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate crypto;
 extern crate hex;
 extern crate libc;
+extern crate sha2;
 #[macro_use]
 extern crate log;
 #[cfg(feature = "pem")]

--- a/src/signing/secp256k1.rs
+++ b/src/signing/secp256k1.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
 #[cfg(feature = "pem")]
 use openssl::{
     bn::{BigNum, BigNumContext},
@@ -30,6 +28,7 @@ use rand::Rng;
 use secp256k1;
 use signing::bytes_to_hex_str;
 use signing::hex_str_to_bytes;
+use sha2::{Digest, Sha256};
 use signing::Context;
 use signing::Error;
 use signing::PrivateKey;
@@ -163,15 +162,12 @@ impl Context for Secp256k1Context {
     }
 
     fn sign(&self, message: &[u8], key: &dyn PrivateKey) -> Result<String, Error> {
-        let mut sha = Sha256::new();
-        sha.input(message);
-        let hash: &mut [u8] = &mut [0; 32];
-        sha.result(hash);
+        let hash = Sha256::digest(message);
 
         let sk = secp256k1::key::SecretKey::from_slice(&self.context, key.as_slice())?;
         let sig = self
             .context
-            .sign(&secp256k1::Message::from_slice(hash)?, &sk)?;
+            .sign(&secp256k1::Message::from_slice(&hash)?, &sk)?;
         let compact = sig.serialize_compact(&self.context);
         Ok(compact
             .iter()
@@ -181,13 +177,10 @@ impl Context for Secp256k1Context {
     }
 
     fn verify(&self, signature: &str, message: &[u8], key: &dyn PublicKey) -> Result<bool, Error> {
-        let mut sha = Sha256::new();
-        sha.input(message);
-        let hash: &mut [u8] = &mut [0; 32];
-        sha.result(hash);
+        let hash = Sha256::digest(message);
 
         let result = self.context.verify(
-            &secp256k1::Message::from_slice(hash)?,
+            &secp256k1::Message::from_slice(&hash)?,
             &secp256k1::Signature::from_compact(&self.context, &hex_str_to_bytes(&signature)?)?,
             &secp256k1::key::PublicKey::from_slice(&self.context, key.as_slice())?,
         );


### PR DESCRIPTION
Issue: rust-crypto is unmaintained and outdated crate:
- https://www.reddit.com/r/rust/comments/dfm3ya/there_are_231_crates_which_might_depend_on_this/
- https://rustsec.org/advisories/RUSTSEC-2016-0005.html

Implementation: replace  rust-crypto with RustCrypto/hashes/sha2