### PR TITLE
Remove pike and sabre smart permissions namespace from xo manifest

### DIFF
--- a/examples/xo_rust/packaging/scar/manifest.yaml
+++ b/examples/xo_rust/packaging/scar/manifest.yaml
@@ -15,10 +15,6 @@
 name: sawtooth_xo
 version: '1.0'
 inputs:
-  - '00ec03'
-  - 'cad11d'
   - '5b7349'
 outputs:
-  - '00ec03'
-  - 'cad11d'
   - '5b7349'


### PR DESCRIPTION
These namespace are not required because the XO contract does not
use pike agents or organizations and the contract does not include
smart permissions.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>