### PR TITLE
Rename 'sawtooth_xo' to 'sawtooth-xo'

### DIFF
--- a/examples/xo_rust/packaging/scar/manifest.yaml
+++ b/examples/xo_rust/packaging/scar/manifest.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: sawtooth_xo
+name: sawtooth-xo
 version: '1.0'
 inputs:
   - '5b7349'


### PR DESCRIPTION
Replaces the underscores, '_', within the smart contract name with
dashes, '-', to adhere to contract naming requirements which prevent
underscores being used in contract names.

Signed-off-by: Shannyn Telander <telander@bitwise.io>