### PR TITLE
Add lib crate to intkey smart contract

### DIFF
--- a/examples/intkey_rust/Cargo.toml
+++ b/examples/intkey_rust/Cargo.toml
@@ -24,6 +24,10 @@ authors = ["Bitwise IO, Inc."]
 name = "intkey-tp-rust"
 path = "src/main.rs"
 
+[lib]
+name = "sawtooth_intkey"
+path = "src/lib.rs"
+
 [dependencies]
 sawtooth-sdk = { path = "../.." }
 rust-crypto = "0.2"

--- a/examples/intkey_rust/src/lib.rs
+++ b/examples/intkey_rust/src/lib.rs
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+extern crate cbor;
+extern crate crypto;
+#[macro_use]
+extern crate log;
+extern crate log4rs;
+extern crate sawtooth_sdk;
+
+pub mod handler;


### PR DESCRIPTION
Adds a lib file to the intkey smart contract, which allows the
smart contract to be used as an external crate.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>