### PR TITLE
Rename `sawtooth_xo` to `xo` in manifest

### DIFF
--- a/examples/xo_rust/packaging/scar/manifest.yaml
+++ b/examples/xo_rust/packaging/scar/manifest.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: sawtooth_xo
+name: xo
 version: '1.0'
 inputs:
   - '5b7349'


### PR DESCRIPTION
When loading smart contract archives from scar files Transact checks that the name in the manifest matches the scar file
name. This commit updates the contract name in the manifest for the xo contract to match the scar file name.