### PR TITLE
Update usage of protobuf to avoid compiler warnings

### DIFF
--- a/src/messaging/zmq_stream.rs
+++ b/src/messaging/zmq_stream.rs
@@ -21,6 +21,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use protobuf::Message as ProtobufMessage;
+
 use crate::messages::validator::Message;
 use crate::messages::validator::Message_MessageType;
 
@@ -263,7 +265,7 @@ impl SendReceiveStream {
                 if let Some(received_bytes) = received_parts.pop() {
                     trace!("Received {} bytes", received_bytes.len());
                     if !received_bytes.is_empty() {
-                        let message = protobuf::parse_from_bytes(&received_bytes).unwrap();
+                        let message = ProtobufMessage::parse_from_bytes(&received_bytes).unwrap();
                         self.inbound_router.route(Ok(message));
                     }
                 } else {

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -45,7 +45,7 @@ use crate::messaging::stream::ReceiveError;
 use crate::messaging::stream::SendError;
 use crate::messaging::zmq_stream::ZmqMessageConnection;
 use crate::messaging::zmq_stream::ZmqMessageSender;
-use protobuf::Message as M;
+use protobuf::Message as ProtobufMessage;
 use protobuf::RepeatedField;
 
 use self::handler::ApplyError;
@@ -229,7 +229,8 @@ impl<'a> TransactionProcessor<'a> {
                         match message.get_message_type() {
                             Message_MessageType::TP_PROCESS_REQUEST => {
                                 let request: TpProcessRequest =
-                                    match protobuf::parse_from_bytes(&message.get_content()) {
+                                    match ProtobufMessage::parse_from_bytes(&message.get_content())
+                                    {
                                         Ok(request) => request,
                                         Err(err) => {
                                             error!("Cannot parse TpProcessRequest: {}", err);

--- a/src/processor/zmq_context.rs
+++ b/src/processor/zmq_context.rs
@@ -16,7 +16,7 @@
  * -----------------------------------------------------------------------------
  */
 
-use protobuf::Message as M;
+use protobuf::Message as ProtobufMessage;
 use protobuf::RepeatedField;
 
 use crate::messages::events::Event;
@@ -76,7 +76,8 @@ impl TransactionContext for ZmqTransactionContext {
             x,
         )?;
 
-        let response: TpStateGetResponse = protobuf::parse_from_bytes(future.get()?.get_content())?;
+        let response: TpStateGetResponse =
+            ProtobufMessage::parse_from_bytes(future.get()?.get_content())?;
         match response.get_status() {
             TpStateGetResponse_Status::OK => {
                 let mut entries = Vec::new();
@@ -130,7 +131,8 @@ impl TransactionContext for ZmqTransactionContext {
             x,
         )?;
 
-        let response: TpStateSetResponse = protobuf::parse_from_bytes(future.get()?.get_content())?;
+        let response: TpStateSetResponse =
+            ProtobufMessage::parse_from_bytes(future.get()?.get_content())?;
         match response.get_status() {
             TpStateSetResponse_Status::OK => Ok(()),
             TpStateSetResponse_Status::AUTHORIZATION_ERROR => {
@@ -167,7 +169,7 @@ impl TransactionContext for ZmqTransactionContext {
         )?;
 
         let response: TpStateDeleteResponse =
-            protobuf::parse_from_bytes(future.get()?.get_content())?;
+            ProtobufMessage::parse_from_bytes(future.get()?.get_content())?;
         match response.get_status() {
             TpStateDeleteResponse_Status::OK => Ok(Vec::from(response.get_addresses())),
             TpStateDeleteResponse_Status::AUTHORIZATION_ERROR => {
@@ -204,7 +206,7 @@ impl TransactionContext for ZmqTransactionContext {
         )?;
 
         let response: TpReceiptAddDataResponse =
-            protobuf::parse_from_bytes(future.get()?.get_content())?;
+            ProtobufMessage::parse_from_bytes(future.get()?.get_content())?;
         match response.get_status() {
             TpReceiptAddDataResponse_Status::OK => Ok(()),
             TpReceiptAddDataResponse_Status::ERROR => Err(ContextError::TransactionReceiptError(
@@ -260,7 +262,8 @@ impl TransactionContext for ZmqTransactionContext {
             x,
         )?;
 
-        let response: TpEventAddResponse = protobuf::parse_from_bytes(future.get()?.get_content())?;
+        let response: TpEventAddResponse =
+            ProtobufMessage::parse_from_bytes(future.get()?.get_content())?;
         match response.get_status() {
             TpEventAddResponse_Status::OK => Ok(()),
             TpEventAddResponse_Status::ERROR => Err(ContextError::TransactionReceiptError(


### PR DESCRIPTION
This primarily replaces protobuf::parse_from_bytes with
Message::parse_from_bytes; the former was deprecated.