### PR TITLE
Update links in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ description = """\
     Hyperledger Sawtooth is an enterprise blockchain platform for building \
     distributed ledger applications and networks.
 """
+repository = "http://github.com/hyperledger/sawtooth-sdk-rust"
 edition = "2018"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ description = """\
     Hyperledger Sawtooth is an enterprise blockchain platform for building \
     distributed ledger applications and networks.
 """
-documentation = "https://sawtooth.hyperledger.org/docs/core/releases/latest/"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
This PR 

- Removes the docs link to the self-published docs (in favor of docs.rs)
- Adds the repository link (such that the repository will be linked from the crates.io page for the library)