### PR TITLE
Fix "needless_late_init" Clippy lint

### DIFF
--- a/examples/intkey_rust/src/main.rs
+++ b/examples/intkey_rust/src/main.rs
@@ -52,13 +52,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LevelFilter::Warn,
-        1 => console_log_level = LevelFilter::Info,
-        2 => console_log_level = LevelFilter::Debug,
-        _ => console_log_level = LevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LevelFilter::Warn,
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(

--- a/examples/xo_rust/src/main.rs
+++ b/examples/xo_rust/src/main.rs
@@ -55,13 +55,12 @@ fn main() {
         .value_of("connect")
         .unwrap_or("tcp://localhost:4004");
 
-    let console_log_level;
-    match matches.occurrences_of("verbose") {
-        0 => console_log_level = LevelFilter::Warn,
-        1 => console_log_level = LevelFilter::Info,
-        2 => console_log_level = LevelFilter::Debug,
-        _ => console_log_level = LevelFilter::Trace,
-    }
+    let console_log_level = match matches.occurrences_of("verbose") {
+        0 => LevelFilter::Warn,
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    };
 
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(


### PR DESCRIPTION
This lint was introduced in 1.59v of Rust

Checks for late initializations that can be replaced by
a let statement with an initializer.

Assigning in the let statement is less repetitive.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>