### PR TITLE
fix: Do not panic on channel send failures

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -58,14 +58,14 @@ fn main() {
         .expect("Unable to write mod file");
 
     protoc_rust::Codegen::new()
-        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .out_dir(dest_path.to_str().expect("Invalid proto destination path"))
         .inputs(
             &proto_src_files
                 .iter()
                 .map(|a| a.as_ref())
                 .collect::<Vec<&str>>(),
         )
-        .includes(&["src", "protos"])
+        .includes(["src", "protos"])
         .customize(Customize::default())
         .run()
         .expect("unable to run protoc");


### PR DESCRIPTION
The expect() calls here are problematic for async clients, as tasks may be cancelled before the reply channel can be serviced. This can result in spurious errors.

* Use .map_err().ok() rather than expect, so message thread can not panic
* Lower logging to warm
* Log socket errors