### PR TITLE
Fix clippy::single_range_in_vec_init lint

### DIFF
--- a/src/consensus/zmq_driver.rs
+++ b/src/consensus/zmq_driver.rs
@@ -44,7 +44,7 @@ const MAX_RETRY_DELAY: Duration = Duration::from_secs(3);
 fn generate_correlation_id() -> String {
     const LENGTH: usize = 16;
     let mut rng = rand::thread_rng();
-    [0..LENGTH]
+    [0; LENGTH]
         .iter()
         .map(|_| rng.sample(Alphanumeric))
         .map(char::from)

--- a/src/consensus/zmq_service.rs
+++ b/src/consensus/zmq_service.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 fn generate_correlation_id() -> String {
     const LENGTH: usize = 16;
     let mut rng = rand::thread_rng();
-    [0..LENGTH]
+    [0; LENGTH]
         .iter()
         .map(|_| rng.sample(Alphanumeric))
         .map(char::from)

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -56,7 +56,7 @@ use self::zmq_context::ZmqTransactionContext;
 fn generate_correlation_id() -> String {
     const LENGTH: usize = 16;
     let mut rng = rand::thread_rng();
-    [0..LENGTH]
+    [0; LENGTH]
         .iter()
         .map(|_| rng.sample(Alphanumeric))
         .map(char::from)


### PR DESCRIPTION
This is almost always incorrect, as it will result in a Vec that has only one element. Almost always, the programmer intended for it to include all elements in the range or for the end of the range to be the length instead.

This means our correlations ids are not 16 characters long like we want. This fixes that issue.